### PR TITLE
Ignore exception and removed trailing nulls (possibly only affects Windows)

### DIFF
--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -83,7 +83,7 @@ def iterfzf(
             stdin.write(line + b'\n')
             stdin.flush()
         except IOError as e:
-            if e.errno != errno.EPIPE:
+            if e.errno != errno.EPIPE and errno.EPIPE != 32:
                 raise
             break
     if proc is None or proc.wait() not in [0, 1]:
@@ -94,11 +94,11 @@ def iterfzf(
     try:
         stdin.close()
     except IOError as e:
-        if e.errno != errno.EPIPE:
+        if e.errno != errno.EPIPE and errno.EPIPE != 32:
             raise
     stdout = proc.stdout
     decode = (lambda b: b) if byte else (lambda t: t.decode(encoding))
-    output = [decode(l.strip(b'\r\n')) for l in iter(stdout.readline, b'')]
+    output = [decode(l.strip(b'\r\n\0')) for l in iter(stdout.readline, b'')]
     if print_query:
         try:
             if multi:


### PR DESCRIPTION
Fixes exception when selecting an option before all are finished loading. Remove trailing null character from returned selected option. These changes have only been tested on Windows so they might not affect other OS's.

The "errno.EPIPE == 32" condition is a "broken pipe" which should be ignored in situations where the user makes a selection before the fzf list has finished loading.