### PR TITLE
Support for --ansi flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,11 @@ The following is the full list of parameters.  Please pass them as
 
    Corresponds to ``--no-mouse`` option.
 
+``ansi``
+   ``True`` to enable processing ANSI color codes.  ``False`` by default.
+
+   Corresponds to ``--ansi`` option.
+
 
 Author and license
 ------------------
@@ -188,6 +193,8 @@ Version 0.6.0.20.0
 ~~~~~~~~~~~~~~~~~~
 
 To be released.  Bundles ``fzf`` 0.20.0.
+
+- Added support for the --ansi option
 
 
 Version 0.5.0.20.0

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -29,7 +29,7 @@ def iterfzf(
     # Search mode:
     extended=True, exact=False, case_sensitive=None,
     # Interface:
-    multi=False, mouse=True, print_query=False,
+    multi=False, mouse=True, print_query=False, ansi=False,
     # Layout:
     prompt='> ',
     preview=None,
@@ -49,6 +49,8 @@ def iterfzf(
         cmd.append('--no-mouse')
     if print_query:
         cmd.append('--print-query')
+    if ansi:
+        cmd.append('--ansi')
     if query:
         cmd.append('--query=' + query)
     if preview:


### PR DESCRIPTION
I'd like to use ansi colour in my options but currently iterfzf won't pass the flag through. This will pass it through.