### PR TITLE
Arbitrary args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,11 @@ The following is the full list of parameters.  Please pass them as
 
    Corresponds to ``--ansi`` option.
 
+``extra_args``
+   An optional list of extra arguments to pass to fzf on the command line,
+   which will be appended to the command.
+   This allows passing in arguments which aren't yet supported by iterfzf.
+
 
 Author and license
 ------------------
@@ -195,6 +200,7 @@ Version 0.6.0.20.0
 To be released.  Bundles ``fzf`` 0.20.0.
 
 - Added support for the --ansi option
+- Added the ability to pass extra arguments to the underlying fzf process
 
 
 Version 0.5.0.20.0

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,11 @@ The following is the full list of parameters.  Please pass them as
 
    Corresponds to ``--no-mouse`` option.
 
+``ansi``
+   ``True`` to enable processing ANSI color codes.  ``False`` by default.
+
+   Corresponds to ``--ansi`` option.
+
 
 Author and license
 ------------------
@@ -188,6 +193,8 @@ Version 0.6.0.20.0
 ~~~~~~~~~~~~~~~~~~
 
 To be released.  Bundles ``fzf`` 0.20.0.
+
+- Added support for the --ansi option
 
 
 Version 0.5.0.20.0

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -29,7 +29,7 @@ def iterfzf(
     # Search mode:
     extended=True, exact=False, case_sensitive=None,
     # Interface:
-    multi=False, mouse=True, print_query=False,
+    multi=False, mouse=True, print_query=False, ansi=False,
     # Layout:
     prompt='> ',
     preview=None,
@@ -49,6 +49,8 @@ def iterfzf(
         cmd.append('--no-mouse')
     if print_query:
         cmd.append('--print-query')
+    if ansi:
+        cmd.append('--ansi')
     if query:
         cmd.append('--query=' + query)
     if preview:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -34,7 +34,8 @@ def iterfzf(
     prompt='> ',
     preview=None,
     # Misc:
-    query='', encoding=None, executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME
+    query='', encoding=None, executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME,
+    extra_args=None
 ):
     cmd = [executable, '--no-sort', '--prompt=' + prompt]
     if not extended:
@@ -55,6 +56,8 @@ def iterfzf(
         cmd.append('--query=' + query)
     if preview:
         cmd.append('--preview=' + preview)
+    if extra_args:
+        cmd.extend(extra_args)
     encoding = encoding or sys.getdefaultencoding()
     proc = None
     stdin = None


### PR DESCRIPTION
Support for arbitrary arguments to append to the underlying fzf command.

I've based this on top of #13 rather than have to immediately resolve conflicts once #13 is merged.