### PR TITLE
Add header_lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,10 @@ The following is the full list of parameters.  Please pass them as
 
    Corresponds to ``--ansi`` option.
 
+``header_lines``
+   A number that dictates which line is supposed to be the header of the iterable. ``None`` by default.
+
+   Corresponds to ``--header-lines`` option.
 
 
 Author and license
@@ -196,6 +200,7 @@ Version 0.6.0.20.0
 To be released.  Bundles ``fzf`` 0.20.0.
 
 Added ``ansi`` option. [`#16` by Erik Lilja]
+Added ``header_lines`` option. [`#17` by Erik Lilja]
 
 
 Version 0.5.0.20.0

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -33,6 +33,7 @@ def iterfzf(
     # Layout:
     prompt='> ',
     ansi=None,
+    header_lines=None,
     preview=None,
     # Misc:
     query='', encoding=None, executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME
@@ -56,6 +57,8 @@ def iterfzf(
         cmd.append('--preview=' + preview)
     if ansi:
         cmd.append('--ansi')
+    if header_lines:
+        cmd.append('--lines=' + str(header_lines))
     encoding = encoding or sys.getdefaultencoding()
     proc = None
     stdin = None

--- a/iterfzf/__init__.pyi
+++ b/iterfzf/__init__.pyi
@@ -15,6 +15,7 @@ def iterfzf(
     # Layout:
     prompt: str = ...,
     ansi: bool = ...,
+    header_lines: int = ...,
     preview: Optional[str] = ...,
     # Misc:
     query: str = ...,


### PR DESCRIPTION
Specifies which element in the iterable is supposed to be the header. Useful if the first element is a header, which would correspond with `--header-lines 1`.

Looks like this, notice the green bottom most text. ![img](https://i.imgur.com/2iqcxx0.png).

