### PR TITLE
removing --no-sort to improve matching

### DIFF
--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -37,7 +37,7 @@ def iterfzf(
     # Misc:
     query='', encoding=None, executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME
 ):
-    cmd = [executable, '--no-sort', '--prompt=' + prompt]
+    cmd = [executable, '--prompt=' + prompt]
     if not extended:
         cmd.append('--no-extended')
     if case_sensitive is not None:


### PR DESCRIPTION
Allow fzf to sort the results list. In effect, this puts higher ranked
matches at the top and fixes the problem stated in issue #18