### PR TITLE
Allows using `--select-1` parameter to fzf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,11 @@ The following is the full list of parameters.  Please pass them as
 
    Corresponds to ``--ansi`` option.
 
+``select_1``
+   ``True`` to exit immediately if there is only one match. ``None`` by default.
+
+   Corresponds to ``--select-1`` option.
+
 
 
 Author and license

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -34,6 +34,7 @@ def iterfzf(
     prompt='> ',
     ansi=None,
     preview=None,
+    select_1=None,
     # Misc:
     query='', encoding=None, executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME
 ):
@@ -56,6 +57,8 @@ def iterfzf(
         cmd.append('--preview=' + preview)
     if ansi:
         cmd.append('--ansi')
+    if select_1:
+        cmd.append('--select-1')
     encoding = encoding or sys.getdefaultencoding()
     proc = None
     stdin = None


### PR DESCRIPTION
This adds a `select_1` parameter to `iterfzf`. If this parameter is added, the `fzf` command is called with the `--select-1` parameter, which means that the command returns immediately when there is only one match.

TODO:
* [ ] Change documentation

It would actually be nice if **all** parameters to `fzf` could be supported, by using a `**kwargs` parameter to `iterfzf`. This should be possible without too much effort:

* Convert underscores in name to dash
* Prepend one-character name with one dash, longer names with two dashes
* A value of `None` or `False` would result in ignoring the parameter
* A value of `True` would add the parameter without argument
* A string or numeric value would add the parameter with this value as argument
