### PR TITLE
Close stdin before waiting to allow --select-1 to work

### DIFF
--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -106,16 +106,16 @@ def iterfzf(
             if e.errno != errno.EPIPE and errno.EPIPE != 32:
                 raise
             break
-    if proc is None or proc.wait() not in [0, 1]:
-        if print_query:
-            return None, None
-        else:
-            return None
     try:
         stdin.close()
     except IOError as e:
         if e.errno != errno.EPIPE and errno.EPIPE != 32:
             raise
+    if proc is None or proc.wait() not in [0, 1]:
+        if print_query:
+            return None, None
+        else:
+            return None
     stdout = proc.stdout
     decode = (lambda b: b) if byte else (lambda t: t.decode(encoding))
     output = [decode(ln.strip(b'\r\n\0')) for ln in iter(stdout.readline, b'')]

--- a/iterfzf/test_iterfzf.py
+++ b/iterfzf/test_iterfzf.py
@@ -1,0 +1,33 @@
+import unittest
+import iterfzf
+
+flavors = [
+    "Chocolate",
+    "Chocolate Chip",
+    "Vanilla",
+    "Strawberry",
+    "Blueberry",
+    "Rocky Road"
+]
+
+
+class IterFzfTest(unittest.TestCase):
+    def test_no_query(self):
+        choice = iterfzf.iterfzf(flavors, executable="fzf")
+        self.assertEqual("Chocolate", choice)
+
+    def test_select_one(self):
+        choice = iterfzf.iterfzf(
+            flavors,
+            query="Vani",
+            __extra__=["-1"],
+            executable="fzf")
+        self.assertEqual("Vanilla", choice)
+
+    def test_select_one_ambiguous(self):
+        choice = iterfzf.iterfzf(
+            flavors,
+            query="Choc",
+            __extra__=["-1"],
+            executable="fzf")
+        self.assertTrue(choice.rfind('Chocolate') == 0)

--- a/iterfzf/test_iterfzf.py
+++ b/iterfzf/test_iterfzf.py
@@ -2,32 +2,25 @@ import unittest
 import iterfzf
 
 flavors = [
-    "Chocolate",
-    "Chocolate Chip",
-    "Vanilla",
-    "Strawberry",
-    "Blueberry",
+    "Chocolate", "Chocolate Chip", "Vanilla", "Strawberry", "Blueberry",
     "Rocky Road"
 ]
 
 
 class IterFzfTest(unittest.TestCase):
+
     def test_no_query(self):
         choice = iterfzf.iterfzf(flavors, executable="fzf")
         self.assertEqual("Chocolate", choice)
 
     def test_select_one(self):
         choice = iterfzf.iterfzf(
-            flavors,
-            query="Vani",
-            __extra__=["-1"],
-            executable="fzf")
+            flavors, query="Vani", __extra__=["-1"], executable="fzf"
+        )
         self.assertEqual("Vanilla", choice)
 
     def test_select_one_ambiguous(self):
         choice = iterfzf.iterfzf(
-            flavors,
-            query="Choc",
-            __extra__=["-1"],
-            executable="fzf")
+            flavors, query="Choc", __extra__=["-1"], executable="fzf"
+        )
         self.assertTrue(choice.rfind('Chocolate') == 0)


### PR DESCRIPTION
Prior to this patch, using the `--select-1` option with iterfzf would result in FZF block indefinitely.  When stdin is left open, `--select-1` would never terminate since FZF anticipates more input and the `POpen.wait()` call just hangs.  By closing stdin before making the call to `POpen.wait()`, FZF is only waiting on user input (if any is required) and not blocking for any other reason.

This patch also includes a very rudimentary unit test suite that can be run with `python -m unittest`.  The suite requires the user to press the enter key.  Presumably there is a way to use unittest.mock to patch stdin and replace it with a defined string so that the test suite can run without manual intervention, but the complexities of that operation eluded me.  My working theory is that it will be necessary to use the pty module to control terminal operations programmatically, but that is beyond my level of expertise.