### PR TITLE
Add 'bind' keyword argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ The following is the full list of parameters.  Pass them as
 
    Corresponds to ``-m``/``--multi`` option.
 
+``bind``
+   The key/event bindings to pass to ``fzf``.
+
+   Dictionary of the form {KEY: ACTION} or {EVENT: ACTION}.
+
+   Corresponds to ``--bind=KEYBINDS`` option.
+
 ``print_query``
    If ``True`` the return type is a tuple where the first element is the query
    the user actually typed, and the second element is the selected output as

--- a/README.rst
+++ b/README.rst
@@ -207,12 +207,24 @@ is 3.4.5.
 .. _Semantic Versioning: http://semver.org/
 
 
-Version 1.4.0.51.0
+Version 1.5.0.51.0
 ~~~~~~~~~~~~~~~~~~
 
 To be released.  Bundles ``fzf`` `0.51.0`__.
 
 __ https://github.com/junegunn/fzf/releases/tag/0.51.0
+
+
+Version 1.4.0.51.0
+~~~~~~~~~~~~~~~~~~
+
+Released on May 7, 2024.  Bundles ``fzf`` `0.51.0`__.
+
+- Added ``bind`` option. [`#21`__, `#36`__ by Gregory.K]
+
+__ https://github.com/junegunn/fzf/releases/tag/0.51.0
+__ https://github.com/dahlia/iterfzf/issues/21
+__ https://github.com/dahlia/iterfzf/pull/36
 
 
 Version 1.3.0.51.0

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -30,7 +30,7 @@ def iterfzf(
     # Search mode:
     extended: bool = True,
     exact: bool = False,
-    case_sensitive: bool = None,
+    case_sensitive: Optional[bool] = None,
     # Interface:
     multi: bool = False,
     mouse: bool = True,

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -62,7 +62,7 @@ def iterfzf(
         cmd.append('--no-mouse')
     if bind:
         bind_options = ','.join(
-            [r"{}:{}".format(key, action) for key, action in bind.items()]
+            r"{}:{}".format(key, action) for key, action in bind.items()
         )
         cmd.append('--bind=' + bind_options)
     if print_query:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -5,7 +5,7 @@ from os import fspath, PathLike
 from pathlib import Path
 import subprocess
 import sys
-from typing import AnyStr, Iterable, Literal, Optional
+from typing import AnyStr, Iterable, Literal, Optional, Dict
 
 __all__ = '__fzf_version__', '__version__', 'BUNDLED_EXECUTABLE', 'iterfzf'
 
@@ -34,6 +34,7 @@ def iterfzf(
     # Interface:
     multi: bool = False,
     mouse: bool = True,
+    bind: Optional[Dict[str, str]] = None,
     print_query: bool = False,
     # Layout:
     prompt: str = '> ',
@@ -59,6 +60,9 @@ def iterfzf(
         cmd.append('--multi')
     if not mouse:
         cmd.append('--no-mouse')
+    if bind:
+        bind_options = ','.join([r"{}:{}".format(key, action) for key, action in bind.items()])
+        cmd.append('--bind=' + bind_options)
     if print_query:
         cmd.append('--print-query')
     if query:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -61,7 +61,9 @@ def iterfzf(
     if not mouse:
         cmd.append('--no-mouse')
     if bind:
-        bind_options = ','.join([r"{}:{}".format(key, action) for key, action in bind.items()])
+        bind_options = ','.join(
+            [r"{}:{}".format(key, action) for key, action in bind.items()]
+        )
         cmd.append('--bind=' + bind_options)
     if print_query:
         cmd.append('--print-query')

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -5,7 +5,7 @@ from os import fspath, PathLike
 from pathlib import Path
 import subprocess
 import sys
-from typing import AnyStr, Iterable, Literal, Optional, Dict
+from typing import AnyStr, Iterable, Literal, Mapping, Optional
 
 __all__ = '__fzf_version__', '__version__', 'BUNDLED_EXECUTABLE', 'iterfzf'
 
@@ -34,7 +34,7 @@ def iterfzf(
     # Interface:
     multi: bool = False,
     mouse: bool = True,
-    bind: Optional[Dict[str, str]] = None,
+    bind: Optional[Mapping[str, str]] = None,
     print_query: bool = False,
     # Layout:
     prompt: str = '> ',


### PR DESCRIPTION
The key/event bindings to pass to 'fzf'.  
Dictionary of the form {KEY: ACTION} or {EVENT: ACTION}.  
Corresponds to `--bind=KEYBINDS` option.

example:  
```python
keybinds = {
    "ctrl-j": "accept",
    "ctrl-k": "kill-line",
}

iterfzf(iterable, bind=keybinds)
```

Related Issue #21

Notes:

- Pull-Request includes a minor fix: 'Annotate 'case_sensitive' as Optional explicitly (according to the general code style/format)'. Please provide guidance on including minor fixes or not.

- The keyword argument 'bind' was placed according to fzf's manual 'categories' under 'Interface'.

- A 'bind' kwarg text snippet has been inserted in the README file. Uncertainty existed regarding the preferred writing style and whether it was appropriate to update the 'Changelog' section. 

Sub-Notes:

It is inferred by code comments that the fzf manual 'categories' are the desired grouping/sorting of the kwargs. If the hypothesis is true, `iterfzf()` keyword arguments and their listing in README should be rearranged and match.