### PR TITLE
Enable tmux integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ The following is the full list of parameters.  Pass them as
      - ``None``
      - ``tmux[=OPTS]``
      - Start fzf in a tmux popup if ``tmux=True`` or the config string is provided (requires tmux 3.3+)
-       [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native] (default: center,50%)
+       ``[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native]`` (default: ``center,50%``)
    * - ``print_query``
      - ``False``
      - ``--print-query``

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,11 @@ The following is the full list of parameters.  Pass them as
      - ``None``
      - ``--preview``
      - *New in version 0.5.0.*
+   * - ``tmux``
+     - ``None``
+     - ``tmux[=OPTS]``
+     - Start fzf in a tmux popup if ``tmux=True`` or the config string is provided (requires tmux 3.3+)
+       [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native] (default: center,50%)
    * - ``print_query``
      - ``False``
      - ``--print-query``

--- a/README.rst
+++ b/README.rst
@@ -146,11 +146,6 @@ The following is the full list of parameters.  Pass them as
      - ``None``
      - ``--preview``
      - *New in version 0.5.0.*
-   * - ``tmux``
-     - ``None``
-     - ``tmux[=OPTS]``
-     - Start fzf in a tmux popup if ``tmux=True`` or the config string is provided (requires tmux 3.3+)
-       ``[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native]`` (default: ``center,50%``)
    * - ``print_query``
      - ``False``
      - ``--print-query``
@@ -173,6 +168,11 @@ The following is the full list of parameters.  Pass them as
      - Sorts the result if ``True``.  ``False`` by default.
 
        *New in version 1.3.0.*
+   * - ``tmux``
+     - ``False``
+     - ``tmux[=OPTS]``
+     - Start fzf in a tmux popup if ``tmux=True`` or the config string is provided (requires tmux 3.3+)
+       ``[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native]`` (default: ``center,50%``)
    * - ``__extra__``
      - ``[]``
      -

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -81,7 +81,7 @@ def iterfzf(
     if preview:
         cmd.append('--preview=' + preview)
     if tmux:
-        cmd.append('--tmux' if tmux is bool else '--tmux={tmux}')
+        cmd.append('--tmux' if tmux is bool else f'--tmux={tmux}')
     if header:
         cmd.append('--header=' + header)
     if ansi:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -49,6 +49,7 @@ def iterfzf(
     ansi: bool = False,
     header: str = '',
     preview: Optional[str] = None,
+    tmux: Optional[str|bool] = False,
     # Misc:
     query: str = '',
     cycle: bool = False,
@@ -79,6 +80,8 @@ def iterfzf(
         cmd.append('--query=' + query)
     if preview:
         cmd.append('--preview=' + preview)
+    if tmux:
+        cmd.append('--tmux' if tmux is bool else '--tmux={tmux}')
     if header:
         cmd.append('--header=' + header)
     if ansi:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -5,7 +5,7 @@ from os import fspath, PathLike
 from pathlib import Path
 import subprocess
 import sys
-from typing import AnyStr, Iterable, Literal, Mapping, Optional
+from typing import AnyStr, Iterable, Literal, Mapping, Optional, Union
 
 __all__ = '__fzf_version__', '__version__', 'BUNDLED_EXECUTABLE', 'iterfzf'
 
@@ -49,7 +49,7 @@ def iterfzf(
     ansi: bool = False,
     header: str = '',
     preview: Optional[str] = None,
-    tmux: Optional[str|bool] = False,
+    tmux: Optional[Union[str, bool]] = False,
     # Misc:
     query: str = '',
     cycle: bool = False,

--- a/iterfzf/test_iterfzf.py
+++ b/iterfzf/test_iterfzf.py
@@ -69,3 +69,23 @@ class IterFzfTest(unittest.TestCase):
             KeyboardInterrupt,
             lambda: iterfzf.iterfzf(flavors, executable="fzf"),
         )
+
+    def test_support_tmux_bool(self):
+        choice = iterfzf.iterfzf(
+            flavors,
+            query="Vani",
+            __extra__=["-1"],
+            executable="fzf",
+            tmux=True,
+        )
+        self.assertEqual("Vanilla", choice)
+
+    def test_support_tmux_str(self):
+        choice = iterfzf.iterfzf(
+            flavors,
+            query="Vani",
+            __extra__=["-1"],
+            executable="fzf",
+            tmux="top,60%",
+        )
+        self.assertEqual("Vanilla", choice)


### PR DESCRIPTION
## Description

This is to allow `fzf` to run on the Tmux window passing the `--tmux` option.

## Changes

- added `tmux` option
- updated documentation
- added tests for the introduced option